### PR TITLE
Fix obsolete time.clock() function

### DIFF
--- a/startup/19-EM_sol_robot.py
+++ b/startup/19-EM_sol_robot.py
@@ -38,11 +38,11 @@ class MethodPV(PV):
 
 def waitReady(timeout=-1):    
 	state = PV("SW:State")
-	start = time.clock()
+	start = time.perf_counter()
 	while True:
 		if state.get() not in ("Running","Moving","Busy","Initialize"):
 			break
-		if (timeout>=0) and ((time.clock() - start) > timeout):
+		if (timeout>=0) and ((time.perf_counter() - start) > timeout):
 			raise Exception("Timeout waiting ready")
 		time.sleep(0.01)
 


### PR DESCRIPTION
replace deprecated  time.clock() with time.perf_counter() in 19-EM_sol_robot.py